### PR TITLE
do not return unexisting row when multiple rows requested

### DIFF
--- a/happybase_mock/table.py
+++ b/happybase_mock/table.py
@@ -107,7 +107,8 @@ class Table(object):
         result = []
         for row in rows:
             data = self.row(row, columns, timestamp, include_timestamp)
-            result.append((row, data))
+            if data:
+                result.append((row, data))
         return result
 
     @_check_table_existence

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -111,7 +111,7 @@ class TestTable(BaseTestCase):
         self.table.put(b'02', {b'd:name': b'Two'}, timestamp=20)
         self.table.put(b'03', {b'd:name': b'Three'}, timestamp=30)
 
-        self.assertEqual(self.table.rows([b'03', b'01', b'02']), [
+        self.assertEqual(self.table.rows([b'03', b'01', b'02', b'not_present']), [
             (b'03', {b'd:name': b'Three'}),
             (b'01', {b'd:name': b'One'}),
             (b'02', {b'd:name': b'Two'})


### PR DESCRIPTION
Actual happybase works as follows:
```python
import happybase as hb
connection = hb.Connection('some.host', use_kerberos=True)
table = connection.table('some_table')
table.rows([b'not present'])
# returns []
```

Happybase moxk does not work similarly:
```python
import happybase_mock as hb_mock
connection = hb_mock.Connection()
connection.create_table('test', {'cf': {}})
table = connection.table('test')
table.rows([b'not present'])
# returns [(b'not present', {})]
```

The PR adds a test that reveals and  fixes the bug.